### PR TITLE
Disable motion on Initialize

### DIFF
--- a/lua/primitive/entities/base.lua
+++ b/lua/primitive/entities/base.lua
@@ -397,6 +397,11 @@ function class:Initialize()
         self:PhysicsInit( SOLID_VPHYSICS )
         self:SetMoveType( MOVETYPE_VPHYSICS )
         self:SetSolid( SOLID_VPHYSICS )
+
+        local physobj = self:GetPhysicsObject()
+        if physobj:IsValid() then
+            physobj:EnableMotion( false )
+        end
     end
 end
 

--- a/lua/primitive/entities/base.lua
+++ b/lua/primitive/entities/base.lua
@@ -399,7 +399,7 @@ function class:Initialize()
         self:SetSolid( SOLID_VPHYSICS )
 
         local physobj = self:GetPhysicsObject()
-        if physobj:IsValid() then
+        if physobj and physobj:IsValid() then
             physobj:EnableMotion( false )
         end
     end


### PR DESCRIPTION
Fixes primitives sometimes getting woken up too early, and simulating with helicopter bomb collisions.

Before, wall has slumped.
![20230926211027_1](https://github.com/shadowscion/Primitive/assets/64710817/09838910-cb11-4afa-b95d-3410049a4938)
Ceiling has fallen
![20230926211035_1](https://github.com/shadowscion/Primitive/assets/64710817/b1fb24c9-96ae-4478-b2c5-13cddc33b9ed)

After, wall is level, corner as sharp as ever!
![20230926211045_1](https://github.com/shadowscion/Primitive/assets/64710817/eb825c28-3dd3-4d11-b3e6-76c6b9465ab5)
Ceiling has not fallen!
![20230926211211_1](https://github.com/shadowscion/Primitive/assets/64710817/e966e5e9-f027-4ead-85fa-5884d78fde82)
