### PR TITLE
Try fixing primitive crash

### DIFF
--- a/lua/primitive/entities/base.lua
+++ b/lua/primitive/entities/base.lua
@@ -390,7 +390,7 @@ function class:Think()
 
         local physobj = self:GetPhysicsObject()
 
-        if physobj:IsValid() and not physobj:IsAsleep() then
+        if physobj:IsValid() and not physobj:IsAsleep() and not self or not self:IsValid() then
             physobj:SetPos( self:GetPos() )
             physobj:SetAngles( self:GetAngles() )
             physobj:EnableMotion( false )


### PR DESCRIPTION
Would resolve #27 if Joshua is right. He said he tested this on his servers and it seems to fix the problem
References: https://github.com/Facepunch/garrysmod-issues/issues/6178

```
Client
    0. SetPos - [C]:-1
      1. (null) - lua/primitive/entities/base.lua:394
```

from Rubat:
It's mostly the physics engine crashes that I am seeing in the list.
The ones you singled out in the list above are mostly self crashes when reaching OOM conditions. The https://github.com/shadowscion/Primitive ones are one of the consistent physics crashes.