### PR TITLE
Actually try to fix the problem

### DIFF
--- a/lua/primitive/entities/base.lua
+++ b/lua/primitive/entities/base.lua
@@ -390,10 +390,7 @@ function class:Think()
 
         local physobj = self:GetPhysicsObject()
 
-        if physobj:IsValid() and not physobj:IsAsleep() and not self or not self:IsValid() then
-            physobj:SetPos( self:GetPos() )
-            physobj:SetAngles( self:GetAngles() )
-            physobj:EnableMotion( false )
+        if physobj:IsValid() then
             physobj:Sleep()
         end
     end


### PR DESCRIPTION
The previous change just breaks clientside collisions entirely, since not self:IsValid() would always be false. Hindsight 20/20, was kinda blinded by how much work I had to put into diagnosing the ultimate problem (https://github.com/Facepunch/garrysmod-issues/issues/6426)

I think the physobj:Sleep() alone is enough (or at least it appears to be for me).
Why? I have no clue! 