### PR TITLE
Fix cl physics not being properly frozen

### DIFF
--- a/lua/primitive/entities/base.lua
+++ b/lua/primitive/entities/base.lua
@@ -391,7 +391,9 @@ function class:Think()
         local physobj = self:GetPhysicsObject()
 
         if physobj:IsValid() then
-            physobj:Sleep()
+            physobj:EnableMotion( false )
+            physobj:SetPos( self:GetPos() )
+            physobj:SetAngles( self:GetAngles() )
         end
     end
 end


### PR DESCRIPTION
Currently the primitive plate isn't really frozen so it has weird glitchy interactions

Example:
https://cdn.steamusercontent.com/ugc/15417798590007718665/C414F8BA6674608DE5474F324C777FC3AD871F6F/
https://cdn.steamusercontent.com/ugc/16269631669476009402/600A007BAA68BF8C41C3ADFEB9D90BD6FBA2F195/
