### PR TITLE
Fix proper clipping compatibility?

### DIFF
--- a/lua/primitive/entities/base.lua
+++ b/lua/primitive/entities/base.lua
@@ -621,6 +621,28 @@ do
         end
     end)
 
+    -- Re-apply any proper_clipping physics clips after each primitive reconstruction.
+    -- Primitives reinitialize via PhysicsInitMultiConvex on every reconstruction, which wipes the clips
+    -- Bypass the race condition by preserving existing clips on rebuild
+    hook.Add("Primitive_PostRebuildPhysics", "Primitive_ProperClipping", function( ent )
+        if not ent.Clipped or not istable( ent.ClipData ) then return end -- no clips to reapply
+        if not ProperClipping or not isfunction( ProperClipping.ClipPhysics ) then return end -- proper_clipping not installed
+
+        -- Aggregate all physics clips
+        local norms, dists = {}, {}
+        local count = 0
+        for _, clip in ipairs( ent.ClipData ) do
+            if clip.physics then
+                count = count + 1
+                norms[count] = clip.norm
+                dists[count] = clip.dist
+            end
+        end
+
+        if count == 0 then return end -- no physics clips to reapply
+
+        ProperClipping.ClipPhysics( ent, norms, dists, true )
+    end)
 end
 
 


### PR DESCRIPTION
<img width="632" height="744" alt="image" src="https://github.com/user-attachments/assets/d7700c26-07be-40d2-8942-43b7f9dec6fc" />

Primitives reinitialize their physics with no regard to proper clips.

On the Server realm, physical clips are wiped after primitives reinitialize.

On the Client realm, physical clips are attempted every 100ms until ent.SpawnEffect happens, which is almost always after the primitive re initializes.

This creates a discrepancy on the client and the server.

To fix this race condition, we should preserve clips after a primitive rebuilds.

We currently have no control over proper clipping, so this is a minimally invasive fix which can accommodate.
