### PR TITLE
Improved clipping retry

### DIFF
--- a/lua/primitive/core/construct.lua
+++ b/lua/primitive/core/construct.lua
@@ -986,8 +986,9 @@ do
             [table] plane -- the plane should have a pos and normal field
 
         @RETURN:
-            [table] abovePlane simpleton
-            [table] belowPlane simpleton
+            [table] abovePlane simpleton -- the piece to keep, or the original mesh unmodified if the plane
+                                          -- didn't cut it, or false if the plane removed the piece entirely
+            [table] belowPlane simpleton -- nil when the plane didn't cut the piece (nothing is discarded)
     --]]
     function meta:Bisect( plane, fillAbove, fillBelow )
         -- Separate original vertices into two tables, determined by
@@ -1007,10 +1008,16 @@ do
             end
         end
 
-        -- If either mesh has a vertex count of 0, there are no
-        -- intersections and we can stop here.
-        if #abovePlane.verts == 0 or #belowPlane.verts == 0 then
-            return false
+        -- If either mesh has a vertex count of 0, the plane didn't
+        -- actually cut this piece, so skip the intersection loop.
+        local nothingBelow = #belowPlane.verts == 0
+        local nothingAbove = #abovePlane.verts == 0
+
+        if nothingBelow or nothingAbove then
+            -- nothingBelow: the whole piece is above the plane and is kept, unmodified.
+            -- nothingAbove: the whole piece is below the plane and is discarded entirely.
+            local kept = nothingBelow and self or false
+            return kept
         end
 
         -- Check each edge of each triangle for an intersection with the plane.
@@ -1066,8 +1073,9 @@ do
             local plane = { pos = clip.Normal * clip.Distance, normal = clip.Normal }
 
             -- Only abovePlane is kept, so only it ever needs capping.
-            model = model:Bisect( plane, not forceOpen and clip.Seal, false )
-            if not model then return false end
+            local abovePlane = model:Bisect( plane, not forceOpen and clip.Seal, false )
+            if not abovePlane then return false end
+            model = abovePlane
         end
 
         return model

--- a/lua/primitive/core/construct.lua
+++ b/lua/primitive/core/construct.lua
@@ -225,6 +225,8 @@ do
                 result.index = {}
                 result.convexes = {}
             end
+
+            result.multiConvex = multiConvex
         end
 
         -- Bad physics table, error model CODE 4

--- a/lua/primitive/core/construct.lua
+++ b/lua/primitive/core/construct.lua
@@ -1575,6 +1575,49 @@ registerType( "error", function( param, data, threaded, physics )
 end )
 
 
+-- part is [base center, apex, ring arc...]; fan-triangulate the side and bottom, and cap both angular
+-- ends (one end is the shape's own sector cut, the other a split introduced purely for convexity).
+-- Shared by CONE's sector split and CYLINDER's degenerate (apex) sector split.
+local function pushSectorConvex( model, part )
+    local n = #part - 2
+
+    local faces = {}
+    for k = 1, n - 1 do
+        faces[#faces + 1] = { 2, 2 + k, 2 + k + 1 } -- side (apex fan)
+        faces[#faces + 1] = { 1, 2 + k + 1, 2 + k } -- bottom (base-center fan)
+    end
+    faces[#faces + 1] = { 2, 1, 3 } -- start cap
+    faces[#faces + 1] = { 2, 1, 2 + n } -- end cap
+
+    model:PushConvex( part, faces )
+end
+
+
+-- vc1/vc2 are the bottom/top center verts; ringPairs[k] is { bottom_k, top_k }. Bottom ring fanned around
+-- vc1, top ring fanned around vc2, side quads between them, both angular ends capped with a flat quad.
+-- Used by CYLINDER's general-frustum sector split.
+local function pushFrustumSectorConvex( model, vc1, vc2, ringPairs )
+    local n = #ringPairs
+
+    local subVerts = { vc1, vc2 }
+    for k = 1, n do
+        subVerts[2 * k + 1] = ringPairs[k][1] -- bottom_k
+        subVerts[2 * k + 2] = ringPairs[k][2] -- top_k
+    end
+
+    local faces = {}
+    for k = 1, n - 1 do
+        faces[#faces + 1] = { 2 * k + 1, 2 * k + 3, 2 * k + 4, 2 * k + 2 } -- side quad
+        faces[#faces + 1] = { 2 * k + 1, 1, 2 * k + 3 } -- bottom fan
+        faces[#faces + 1] = { 2 * k + 2, 2 * k + 4, 2 } -- top fan
+    end
+    faces[#faces + 1] = { 1, 3, 4, 2 } -- start cap
+    faces[#faces + 1] = { 1, 2 * n + 1, 2 * n + 2, 2 } -- end cap
+
+    model:PushConvex( subVerts, faces )
+end
+
+
 -- CONE
 registerType( "cone", function( param, data, threaded, physics )
     local maxseg = param.PrimMAXSEG or 32
@@ -1604,7 +1647,7 @@ registerType( "cone", function( param, data, threaded, physics )
     model:PushXYZ( 0, 0, -dz )
     model:PushXYZ( -dx * tx, dy * ty, dz )
 
-    if CLIENT then
+    if CLIENT or physics then
         for i = 1, c0 - 1 do
             model:PushTriangle( i, i + 1, c2 )
             model:PushTriangle( i, c1, i + 1 )
@@ -1632,11 +1675,14 @@ registerType( "cone", function( param, data, threaded, physics )
                     table_insert( convexes[2], verts[i] )
                 end
             end
+
+            for h = 1, 2 do
+                pushSectorConvex( model, convexes[h] )
+            end
         else
             convexes = { verts }
+            model.convexes = convexes
         end
-
-        model.convexes = convexes
     end
 
     util_Transform( verts, param.PrimMESHROT, param.PrimMESHPOS, threaded )
@@ -1663,7 +1709,7 @@ registerType( "cube", function( param, data, threaded, physics )
         model:PushXYZ( -dx, dy, -dz )
         model:PushXYZ( 0, 0, dz )
 
-        if CLIENT then
+        if CLIENT or physics then
             model:PushTriangle( 1, 2, 5 )
             model:PushTriangle( 2, 4, 5 )
             model:PushTriangle( 4, 3, 5 )
@@ -1680,7 +1726,7 @@ registerType( "cube", function( param, data, threaded, physics )
         model:PushXYZ( -dx * tx, dy * ty, dz )
         model:PushXYZ( -dx * tx, -dy * ty, dz )
 
-        if CLIENT then
+        if CLIENT or physics then
             model:PushFace( 1, 2, 3, 4 )
             model:PushFace( 2, 6, 7, 3 )
             model:PushFace( 6, 5, 8, 7 )
@@ -1743,12 +1789,6 @@ registerType( "cube_magic", function( param, data, threaded, physics )
 
     local model = simpleton.New()
     local verts = model.verts
-
-    local convexes
-    if physics then
-        convexes = {}
-        model.convexes = convexes
-    end
 
     local ibuffer = 1
 
@@ -1818,16 +1858,13 @@ registerType( "cube_magic", function( param, data, threaded, physics )
 
             if physics then
                 local count = #verts
-                convexes[#convexes + 1] = {
-                    verts[count - 0],
-                    verts[count - 1],
-                    verts[count - 2],
-                    verts[count - 3],
-                    verts[count - 4],
-                    verts[count - 5],
-                    verts[count - 6],
-                    verts[count - 7],
-                }
+                model:PushConvex( {
+                    verts[count - 7], verts[count - 6], verts[count - 5], verts[count - 4],
+                    verts[count - 3], verts[count - 2], verts[count - 1], verts[count - 0],
+                }, {
+                    { 1, 3, 5, 7 }, { 4, 2, 8, 6 }, { 2, 1, 7, 8 },
+                    { 3, 4, 6, 5 }, { 6, 8, 7, 5 }, { 1, 2, 4, 3 },
+                } )
             end
 
             if CLIENT then
@@ -1882,18 +1919,10 @@ registerType( "cube_hole", function( param, data, threaded, physics )
         model:PushFace( 8, 7, 1, 4 )
     end
 
-    if physics then
-        convexes = {}
-        model.convexes = convexes
-    end
-
     for i = 0, numseg - 1 do
         vec_rotate( cube_corner0, cube_angle )
         vec_rotate( cube_corner1, cube_angle )
         vec_rotate( cube_corner2, cube_angle )
-
-        local part
-        if physics then part = {} end
 
         model:PushXYZ( cube_corner0.x * dx, cube_corner0.y * dy, -dz )
         model:PushXYZ( cube_corner1.x * dx, cube_corner1.y * dy, -dz )
@@ -1917,7 +1946,7 @@ registerType( "cube_hole", function( param, data, threaded, physics )
 
         local count_end1 = #verts
         if physics then
-            convexes[#convexes + 1] = {
+            model:PushBoxConvex( {
                 verts[count_end0 - 0],
                 verts[count_end0 - 3],
                 verts[count_end0 - 4],
@@ -1927,7 +1956,8 @@ registerType( "cube_hole", function( param, data, threaded, physics )
                 verts[count_end1 - ring_steps1 * 0.5],
                 verts[count_end1 - ring_steps1 * 0.5 - 1],
             }
-            convexes[#convexes + 1] = {
+            , { 1, 4, 5, 7 }, { 2, 3, 6, 8 } )
+            model:PushBoxConvex( {
                 verts[count_end0 - 2],
                 verts[count_end0 - 5],
                 verts[count_end0 - 4],
@@ -1937,6 +1967,7 @@ registerType( "cube_hole", function( param, data, threaded, physics )
                 verts[count_end1 - ring_steps1 * 0.5],
                 verts[count_end1 - ring_steps1 * 0.5 - 1],
             }
+            , { 1, 4, 5, 7 }, { 2, 3, 6, 8 } )
         end
 
         if CLIENT then
@@ -2001,7 +2032,7 @@ registerType( "cylinder", function( param, data, threaded, physics )
     model:PushXYZ( 0, 0, -dz )
     model:PushXYZ( 0, 0, dz )
 
-    if CLIENT then
+    if CLIENT or physics then
         if tx == 0 and ty == 0 then
             for i = 1, c0 - 1 do
                 model:PushTriangle( i, i + 1, c2 )
@@ -2027,10 +2058,8 @@ registerType( "cylinder", function( param, data, threaded, physics )
     end
 
     if physics then
-        local convexes
-
         if numseg ~= maxseg then
-            convexes = {
+            local convexes = {
                 { verts[c1], verts[c2] },
                 { verts[c1], verts[c2] },
             }
@@ -2044,21 +2073,31 @@ registerType( "cylinder", function( param, data, threaded, physics )
                         table_insert( convexes[2], verts[i] )
                     end
                 end
+
+                -- Degenerate (apex) cylinder: same split-fan topology as CONE's sector case above.
+                for h = 1, 2 do
+                    pushSectorConvex( model, convexes[h] )
+                end
             else
-                for i = 1, c0 do
+                -- General frustum: bottom ring fanned around c1, top ring fanned around c2, side quads
+                -- between them, each half capped at both angular ends with a flat (c1, bottom, top, c2) quad.
+                local halves = { {}, {} }
+                for i = 1, c0, 2 do
                     if i - ( maxseg > 3 and 2 or 1 ) <= maxseg then
-                        table_insert( convexes[1], verts[i] )
+                        table_insert( halves[1], { verts[i], verts[i + 1] } )
                     end
                     if i - 1 >= maxseg then
-                        table_insert( convexes[2], verts[i] )
+                        table_insert( halves[2], { verts[i], verts[i + 1] } )
                     end
+                end
+
+                for h = 1, 2 do
+                    pushFrustumSectorConvex( model, verts[c1], verts[c2], halves[h] )
                 end
             end
         else
-            convexes = { verts }
+            model.convexes = { verts }
         end
-
-        model.convexes = convexes
     end
 
     util_Transform( verts, param.PrimMESHROT, param.PrimMESHPOS, threaded )
@@ -2187,19 +2226,18 @@ registerType( "dome_hollow", function( param, data, threaded, physics )
 
         -- One convex per patch: four outer corners + four inner corners of each wall quad.
         -- This approximates the hollow shell as a set of thin wedge-shaped convex hulls.
-        local convexes = {}
         for r = 0, physNumseg2 - 1 do
             for v = 0, physNumseg - 1 do
                 local oa = 1 + r * physTwoRing + v * 2  -- bottom-left outer
                 local od = oa + physTwoRing             -- top-left outer
-                convexes[#convexes + 1] = {
+                model:PushBoxConvex( {
                     physVerts[oa],     physVerts[oa + 2], physVerts[od],     physVerts[od + 2],  -- outer quad corners
                     physVerts[oa + 1], physVerts[oa + 3], physVerts[od + 1], physVerts[od + 3],  -- inner quad corners
                 }
+                , { 1, 2, 4, 3 }, { 5, 6, 8, 7 } )
             end
         end
 
-        model.convexes = convexes
         util_Transform( physVerts, param.PrimMESHROT, param.PrimMESHPOS, threaded )
     end
 
@@ -2276,7 +2314,7 @@ registerType( "pyramid", function( param, data, threaded, physics )
     model:PushXYZ( -dx, dy, -dz )
     model:PushXYZ( -dx * tx, dy * ty, dz )
 
-    if CLIENT then
+    if CLIENT or physics then
         model:PushTriangle( 1, 2, 5 )
         model:PushTriangle( 2, 4, 5 )
         model:PushTriangle( 4, 3, 5 )
@@ -2358,6 +2396,7 @@ registerType( "sphere", function( param, data, threaded, physics )
                 end
 
                 model.convexes = { convex.verts }
+                model.convexSimpletons = { convex }
 
                 util_Transform( convex.verts, param.PrimMESHROT, param.PrimMESHPOS, threaded )
             end
@@ -2379,6 +2418,31 @@ registerType( "sphere", function( param, data, threaded, physics )
     return model
 
 end, { canThread = true } )
+
+
+-- part is numring quads forming a closed poloidal barrel between angle i and i+1. Cap both ends with the
+-- numring-gon ring of "front" (angle i) and "back" (angle i+1) points.
+-- Used by TORUS.
+local function pushBarrelConvex( model, part, numring )
+    local faces = {}
+    local front = { 2 }
+    local back = { 3 }
+
+    for j = 1, numring do
+        local base = 4 * ( j - 1 )
+        faces[#faces + 1] = { base + 1, base + 2, base + 3, base + 4 }
+
+        if j < numring then
+            front[#front + 1] = base + 1
+            back[#back + 1] = base + 4
+        end
+    end
+
+    faces[#faces + 1] = front
+    faces[#faces + 1] = table.Reverse( back )
+
+    model:PushConvex( part, faces )
+end
 
 
 -- TORUS
@@ -2445,20 +2509,17 @@ registerType( "torus", function( param, data, threaded, physics )
             end
         end
 
-        local convexes = {}
-        model.convexes = convexes
+        for i = 1, numseg do
+            local part = {}
 
-        for j = 1, numring do
-            for i = 1, numseg do
-                if not convexes[i] then
-                    convexes[i] = {}
-                end
-                local part = convexes[i]
+            for j = 1, numring do
                 part[#part + 1] = pverts[( maxseg + 1 ) * j + i]
                 part[#part + 1] = pverts[( maxseg + 1 ) * ( j - 1 ) + i]
                 part[#part + 1] = pverts[( maxseg + 1 ) * ( j - 1 ) + i + 1]
                 part[#part + 1] = pverts[( maxseg + 1 ) * j + i + 1]
             end
+
+            pushBarrelConvex( model, part, numring )
         end
 
         util_Transform( pverts, param.PrimMESHROT, param.PrimMESHPOS, threaded )
@@ -2547,16 +2608,15 @@ registerType( "tube", function( param, data, threaded, physics )
     end
 
     if physics then
-        local convexes = {}
-        model.convexes = convexes
-
         if iscone then
             for i = 1, c0 - 2, 2 do
-                convexes[#convexes + 1] = { verts[c2], verts[i], verts[i + 1], verts[i + 2], verts[i + 3] }
+                model:PushConvex( { verts[c2], verts[i], verts[i + 1], verts[i + 2], verts[i + 3] }
+                , { { 5, 4, 2, 3 }, { 2, 4, 1 }, { 5, 3, 1 }, { 1, 2, 3 }, { 1, 5, 4 } } )
             end
         else
             for i = 1, c0 - 4, 4 do
-                convexes[#convexes + 1] = { verts[i], verts[i + 1], verts[i + 2], verts[i + 3], verts[i + 4], verts[i + 5], verts[i + 6], verts[i + 7] }
+                model:PushBoxConvex( { verts[i], verts[i + 1], verts[i + 2], verts[i + 3], verts[i + 4], verts[i + 5], verts[i + 6], verts[i + 7] }
+                , { 1, 2, 3, 4 }, { 5, 6, 7, 8 } )
             end
         end
     end
@@ -2596,7 +2656,7 @@ registerType( "wedge", function( param, data, threaded, physics )
 
     end
 
-    if CLIENT then
+    if CLIENT or physics then
         if ty == 0 then
             model:PushTriangle( 1, 2, 5 )
             model:PushTriangle( 2, 4, 5 )
@@ -2641,7 +2701,7 @@ registerType( "wedge_corner", function( param, data, threaded, physics )
     model:PushXYZ( -dx, dy, -dz )
     model:PushXYZ( -dx * tx, dy * ty, dz )
 
-    if CLIENT then
+    if CLIENT or physics then
         model:PushTriangle( 1, 3, 4 )
         model:PushTriangle( 2, 1, 4 )
         model:PushTriangle( 3, 2, 4 )
@@ -2680,7 +2740,7 @@ registerType( "parallelogram", function( param, data, threaded, physics )
     model:PushXYZ( -dx + shift, -dy,  dz )  -- 7 top y- x-
     model:PushXYZ( -dx + shift,  dy,  dz )  -- 8 top y+ x-
 
-    if CLIENT then
+    if CLIENT or physics then
         model:PushFace( 1, 2, 3, 4 )  -- bottom (-z)
         model:PushFace( 5, 8, 7, 6 )  -- top (+z)
         model:PushFace( 1, 4, 8, 5 )  -- y+ side
@@ -2970,6 +3030,7 @@ end )
 registerType( "rail_slider", function( param, data, threaded, physics )
     local model = simpleton.New()
     model.convexes = {}
+    model.convexSimpletons = {}
 
     -- base
     local bpos = isvector( param.PrimBPOS ) and Vector( param.PrimBPOS ) or Vector( 1, 1, 1 )
@@ -2987,7 +3048,7 @@ registerType( "rail_slider", function( param, data, threaded, physics )
 
     -- base
     if tobool( param.PrimBASE ) then
-        model:PushPrefab( "cube", bpos, nil, bdim, CLIENT, model.convexes )
+        model:PushPrefab( "cube", bpos, nil, bdim, CLIENT, model.convexes, nil, model.convexSimpletons )
     end
 
     -- contact point
@@ -3031,7 +3092,7 @@ registerType( "rail_slider", function( param, data, threaded, physics )
                     pos = pos - ( rot:Right() * ( fdim.y * 0.5 + cdim.y * 0.5 ) * side.y )
                     pos = pos + ( rot:Up() * ( cdim.z * 0.5 - fdim.z * 0.5 ) )
 
-                    model:PushPrefab( ftype, pos, rot, fdim, CLIENT, model.convexes )
+                    model:PushPrefab( ftype, pos, rot, fdim, CLIENT, model.convexes, nil, model.convexSimpletons )
                 end
             end
         end
@@ -3048,13 +3109,13 @@ registerType( "rail_slider", function( param, data, threaded, physics )
             local rot = Angle( -crot.p * side.x, crot.y * side.x * side.y, crot.r * side.y )
 
             pos.x = pos.x + ( cdim.x * side.x * 0.5 )
-            model:PushPrefab( ctype, pos, rot, cdim, CLIENT, model.convexes )
+            model:PushPrefab( ctype, pos, rot, cdim, CLIENT, model.convexes, nil, model.convexSimpletons )
 
             if getflange then getflange( i, pos, rot, side ) end
 
             if double then
                 pos = pos - ( rot:Right() * side.y * cgap )
-                model:PushPrefab( ctype, pos, rot, cdim, CLIENT, model.convexes )
+                model:PushPrefab( ctype, pos, rot, cdim, CLIENT, model.convexes, nil, model.convexSimpletons )
             end
         end
     end
@@ -3075,10 +3136,6 @@ registerType( "staircase", function( param, data, threaded, physics )
     local model = simpleton.New()
     local verts = model.verts
 
-    if physics then
-        model.convexes = {}
-    end
-
     for i = 0, count - 1 do
         local a = model:PushXYZ( run * i, width, rise * i )
         local b = model:PushXYZ( run * i, width, rise * i + rise )
@@ -3089,7 +3146,7 @@ registerType( "staircase", function( param, data, threaded, physics )
         local f = model:CopyVertex( c, nil, -width, nil )
 
         if physics then
-            model.convexes[#model.convexes + 1] = {
+            model:PushConvex( {
                 verts[a],
                 verts[b],
                 verts[c],
@@ -3097,6 +3154,10 @@ registerType( "staircase", function( param, data, threaded, physics )
                 verts[e],
                 verts[f],
             }
+            , {
+                { 1, 2, 3 }, { 6, 5, 4 },
+                { 1, 2, 5, 4 }, { 2, 3, 6, 5 }, { 3, 1, 4, 6 },
+            } )
         end
 
         if CLIENT then
@@ -3118,7 +3179,7 @@ registerType( "staircase", function( param, data, threaded, physics )
         local b = model:PushXYZ( run * count, -width,  0 )
 
         if physics then
-            model.convexes[#model.convexes + 1] = {
+            model:PushConvex( {
                 verts[count * 6 - 3],
                 verts[count * 6],
                 verts[1],
@@ -3126,6 +3187,10 @@ registerType( "staircase", function( param, data, threaded, physics )
                 verts[a],
                 verts[b]
             }
+            , {
+                { 3, 5, 1 }, { 2, 6, 4 },
+                { 3, 5, 6, 4 }, { 5, 1, 2, 6 }, { 1, 3, 4, 2 },
+            } )
         end
 
         if CLIENT then
@@ -3158,6 +3223,7 @@ registerType( "ladder", function( param, data, threaded, physics )
 
     if physics then
         model.convexes = {}
+        model.convexSimpletons = {}
     end
 
     local isSolid = bit.band( tonumber( param.PrimSOPT ) or 0, 1 ) == 1
@@ -3173,12 +3239,12 @@ registerType( "ladder", function( param, data, threaded, physics )
     local rz = math_min( height, math_clamp( rdim.z, 1, 50 ) )
 
     for i = 0, count - 1 do
-        model:PushPrefab( "cube", Vector( 0, 0, height * i ), Angle(), Vector( rx, ry, rz ), CLIENT, not isSolid and model.convexes )
+        model:PushPrefab( "cube", Vector( 0, 0, height * i ), Angle(), Vector( rx, ry, rz ), CLIENT, not isSolid and model.convexes, nil, not isSolid and model.convexSimpletons )
     end
 
     if isSolid and physics then
         local size = height * ( count - 1 )
-        model:PushPrefab( "cube", Vector( 0, 0, size * 0.5 ), Angle(), Vector( rx, ry, size + rz ), nil, model.convexes )
+        model:PushPrefab( "cube", Vector( 0, 0, size * 0.5 ), Angle(), Vector( rx, ry, size + rz ), nil, model.convexes, nil, model.convexSimpletons )
     end
 
     -- rail
@@ -3191,8 +3257,8 @@ registerType( "ladder", function( param, data, threaded, physics )
 
         local xsize = Vector( xx, xy, height * ( count - 1 ) + xz )
 
-        model:PushPrefab( "cube", Vector( 0, ry * 0.5 + xy * 0.5, xsize.z * 0.5 - xz * 0.5 ), Angle(), xsize, CLIENT, model.convexes )
-        model:PushPrefab( "cube", Vector( 0, -ry * 0.5 - xy * 0.5, xsize.z * 0.5 - xz * 0.5 ), Angle(), xsize, CLIENT, model.convexes )
+        model:PushPrefab( "cube", Vector( 0, ry * 0.5 + xy * 0.5, xsize.z * 0.5 - xz * 0.5 ), Angle(), xsize, CLIENT, model.convexes, nil, model.convexSimpletons )
+        model:PushPrefab( "cube", Vector( 0, -ry * 0.5 - xy * 0.5, xsize.z * 0.5 - xz * 0.5 ), Angle(), xsize, CLIENT, model.convexes, nil, model.convexSimpletons )
     end
 
     util_Transform( model.verts, param.PrimMESHROT, param.PrimMESHPOS, threaded )

--- a/lua/primitive/core/construct.lua
+++ b/lua/primitive/core/construct.lua
@@ -187,15 +187,18 @@ do
             return true, errorModel( 3, name )
         end
 
+        -- Whether this build is multi-convex, independent of whether there are any clips to apply
+        -- right now -- ImprovedClippingAllowSeal needs this even with zero stored clips.
+        local preConvexes = result.convexes
+        local preConvexSimpletons = result.convexSimpletons
+        local multiConvex = istable( preConvexSimpletons ) or ( istable( preConvexes ) and #preConvexes > 1 )
+        result.multiConvex = multiConvex
+
         -- ImprovedClipping delegation: bisect against every stored clip, capping per Seal.
         if clips and clips[1] and result.ApplyClips then
-            local preConvexes = result.convexes
-            local preConvexSimpletons = result.convexSimpletons
             local preVerts = result.verts
 
             -- Force the unitary render mesh's cut open when multi-convex, since its cross-section is concave and the cap fan only works on a convex loop.
-            local multiConvex = istable( preConvexSimpletons ) or ( istable( preConvexes ) and #preConvexes > 1 )
-
             local clipped = result:ApplyClips( clips, multiConvex )
 
             if clipped then

--- a/lua/primitive/core/construct.lua
+++ b/lua/primitive/core/construct.lua
@@ -174,7 +174,7 @@ do
         return result
     end
 
-    local function getResult( construct, name, param, threaded, physics )
+    local function getResult( construct, name, param, threaded, physics, clips )
         local success, result = pcall( construct.factory, param, construct.data, threaded, physics )
 
         -- lua error, error model CODE 2
@@ -185,6 +185,46 @@ do
         -- Bad return, error model CODE 3
         if not istable( result ) then
             return true, errorModel( 3, name )
+        end
+
+        -- ImprovedClipping delegation: bisect against every stored clip, capping per Seal.
+        if clips and clips[1] and result.ApplyClips then
+            local preConvexes = result.convexes
+            local preConvexSimpletons = result.convexSimpletons
+            local preVerts = result.verts
+
+            -- Force the unitary render mesh's cut open when multi-convex, since its cross-section is concave and the cap fan only works on a convex loop.
+            local multiConvex = istable( preConvexSimpletons ) or ( istable( preConvexes ) and #preConvexes > 1 )
+
+            local clipped = result:ApplyClips( clips, multiConvex )
+
+            if clipped then
+                result = clipped
+
+                if istable( preConvexSimpletons ) then
+                    -- Multi-convex shapes: clip each piece's own triangulated simpleton individually.
+                    local newConvexes = {}
+
+                    for i = 1, #preConvexSimpletons do
+                        local clippedSub = preConvexSimpletons[i]:ApplyClips( clips )
+                        if clippedSub then
+                            newConvexes[#newConvexes + 1] = clippedSub.verts
+                        end
+                    end
+
+                    result.convexes = newConvexes
+                elseif istable( preConvexes ) and preConvexes[1] == preVerts then
+                    -- Single-convex shapes whose convex hull literally is their vertex table can be re-derived directly.
+                    result.convexes = { result.verts }
+                else
+                    -- Anything else keeps its original, unclipped convex hulls for now.
+                    result.convexes = preConvexes
+                end
+            else
+                result.verts = {}
+                result.index = {}
+                result.convexes = {}
+            end
         end
 
         -- Bad physics table, error model CODE 4
@@ -228,11 +268,12 @@ do
             [table] param      -- passed to the builder function
             [boolean] threaded -- return a coroutine (if possible)
             [boolean] physics  -- generate a collison model
+            [table] clips      -- ImprovedClipping clips to bisect the result against, optional
 
         @RETURN:
             either a function or a coroutine that will build the mesh
     --]]
-    function addon.construct.generate( construct, param, threaded, physics )
+    function addon.construct.generate( construct, param, threaded, physics, clips )
         if SERVER then threaded = nil end
 
         -- Non-existant construct, error model CODE 1
@@ -246,12 +287,12 @@ do
         -- Expected yield: true, true, table
         if threaded and construct.data.canThread then
             return true, coroutine.create( function()
-                coroutine_yield( getResult( construct, name, param, true, physics ) )
+                coroutine_yield( getResult( construct, name, param, true, physics, clips ) )
             end )
         end
 
         -- Expected return: true, table
-        return getResult( construct, name, param, false, physics )
+        return getResult( construct, name, param, false, physics, clips )
     end
 
 
@@ -265,11 +306,12 @@ do
             [table] param      -- passed to the builder function
             [boolean] threaded -- return a coroutine (if possible)
             [boolean] physics  -- generate a collison model
+            [table] clips      -- ImprovedClipping clips to bisect the result against, optional
 
         @RETURN:
             either a function or a coroutine that will build the mesh
     --]]
-    function addon.construct.get( name, param, threaded, physics )
+    function addon.construct.get( name, param, threaded, physics, clips )
         if param and param.PrimUNITS == "centimeters" then
             param = table.Copy( param )
             if isvector( param.PrimSIZE ) then
@@ -279,7 +321,7 @@ do
             if isnumber( param.PrimDT ) then param.PrimDT = math_max( param.PrimDT * 0.3937, MinSize ) end
             if isnumber( param.PrimSLANT ) then param.PrimSLANT = param.PrimSLANT * 0.3937 end
         end
-        return addon.construct.generate( construct_types[name], param, threaded, physics )
+        return addon.construct.generate( construct_types[name], param, threaded, physics, clips )
     end
 end
 
@@ -305,6 +347,72 @@ do
     --]]
     function simpleton.New()
         return setmetatable( { verts = {}, index = {}, key = {} }, meta )
+    end
+
+
+    --[[
+        @FUNCTION: simpleton:PushConvex
+
+        @DESCRIPTION: Register one physics convex piece: build a standalone sub-simpleton from a vertex list and a
+                      set of local-index face tuples, then append it to self.convexes/self.convexSimpletons (lazily
+                      created on first call). The counterpart to PushFace/PushTriangle for physics hulls -- those
+                      build self's own render index in place, this builds and registers a separate bisectable
+                      convex piece so ImprovedClipping can cut each one individually.
+
+        @PARAMETERS:
+            [table] verts -- vertex table, shared by reference (not copied)
+            [table] faces -- list of local-index tuples, e.g. { {1,2,3,4}, {5,6,7,8}, ... }
+
+        @RETURN:
+            [table] the pushed sub-simpleton
+    --]]
+    function meta:PushConvex( verts, faces )
+        if not self.convexes then
+            self.convexes = {}
+            self.convexSimpletons = {}
+        end
+
+        local sub = simpleton.New()
+        sub.verts = verts
+
+        for i = 1, #faces do
+            sub:PushFaceTable( faces[i] )
+        end
+
+        self.convexSimpletons[#self.convexSimpletons + 1] = sub
+        self.convexes[#self.convexes + 1] = sub.verts
+
+        return sub
+    end
+
+
+    --[[
+        @FUNCTION: simpleton:PushBoxConvex
+
+        @DESCRIPTION: PushConvex for a hexahedron described as two parallel 4-point loops (e.g. a top ring and a
+                      bottom ring), where top[i] and bottom[i] are the same corner on opposite loops. Generalizes
+                      the "8 verts, 6 quad faces" prism pattern shared by cube-like multi-convex shapes.
+
+        @PARAMETERS:
+            [table] verts  -- vertex table, shared by reference (not copied)
+            [table] top    -- 4 local indices into verts, one loop
+            [table] bottom -- 4 local indices into verts, the corresponding opposite loop
+
+        @RETURN:
+            [table] the pushed sub-simpleton
+    --]]
+    function meta:PushBoxConvex( verts, top, bottom )
+        local faces = {
+            top,
+            { bottom[4], bottom[3], bottom[2], bottom[1] },
+        }
+
+        for i = 1, 4 do
+            local j = i % 4 + 1
+            faces[#faces + 1] = { top[i], top[j], bottom[j], bottom[i] }
+        end
+
+        return self:PushConvex( verts, faces )
     end
 
 
@@ -388,11 +496,13 @@ do
             [boolean] pushindex
             [table] additional table to add vertices to (optional)
             [number] subtable id of ^, increments if not given (optional)
+            [table] if given, and vtable auto-nested a fresh subtable this call, appends a bisectable
+                    simpleton for that subtable's convex piece (sharing the prefab's own index) (optional)
 
         @RETURN:
             [table] key table of added vertices
     --]]
-    function meta:PushPrefab( name, pos, ang, scale, pushindex, vtable, vtableN )
+    function meta:PushPrefab( name, pos, ang, scale, pushindex, vtable, vtableN, convexSimpletons )
         local prefab = prefab_types[name]
         if not prefab then
             return
@@ -401,7 +511,8 @@ do
         local key = {}
         local verts, index = prefab.verts, prefab.index
 
-        if vtable and not vtableN then
+        local ownVtable = vtable and not vtableN
+        if ownVtable then
             vtable[#vtable + 1] = {}
             vtable = vtable[#vtable]
         end
@@ -419,6 +530,13 @@ do
             key[i] = n
 
             if vtable then vtable[#vtable + 1] = vertex end
+        end
+
+        if convexSimpletons and ownVtable then
+            local sub = simpleton.New()
+            sub.verts = vtable
+            sub.index = index
+            convexSimpletons[#convexSimpletons + 1] = sub
         end
 
         if pushindex then
@@ -923,6 +1041,36 @@ do
         belowPlane.key = {}
 
         return abovePlane, belowPlane
+    end
+
+
+    --[[
+        @FUNCTION: simpleton:ApplyClips
+
+        @DESCRIPTION: Cut a simpleton against a list of ImprovedClipping-style local clip planes, capping per each clip's Seal flag.
+
+        @PARAMETERS:
+            [table] clips -- { { Normal = vector, Distance = number, Seal = bool }, ... }, entity-local
+            [boolean] forceOpen -- leave every cut open regardless of the clips' Seal flags
+
+        @RETURN:
+            [table] the clipped simpleton, or false if the clips together removed the whole mesh
+    --]]
+    function meta:ApplyClips( clips, forceOpen )
+        if not clips or not clips[1] then return self end
+
+        local model = self
+
+        for i = 1, #clips do
+            local clip = clips[i]
+            local plane = { pos = clip.Normal * clip.Distance, normal = clip.Normal }
+
+            -- Only abovePlane is kept, so only it ever needs capping.
+            model = model:Bisect( plane, not forceOpen and clip.Seal, false )
+            if not model then return false end
+        end
+
+        return model
     end
 
 

--- a/lua/primitive/entities/base.lua
+++ b/lua/primitive/entities/base.lua
@@ -224,6 +224,17 @@ function class:PrimitiveRebuildPhysics( result )
 
         if not cphysics then
             Primitive.funcs.log( self, "invalid convexes" )
+        elseif CLIENT then
+            -- Clientside vphysics doesn't reliably pick up a rebuilt collision shape on its own
+            -- (see the Think() workaround above for the related bug). This works empirically. Trust me bro.
+            local physobj = self:GetPhysicsObject()
+
+            if physobj:IsValid() then
+                physobj:EnableMotion( false )
+                physobj:SetPos( self:GetPos() )
+                physobj:SetAngles( self:GetAngles() )
+                physobj:Wake()
+            end
         end
     end
 

--- a/lua/primitive/entities/base.lua
+++ b/lua/primitive/entities/base.lua
@@ -71,7 +71,12 @@ end
 function class:PrimitiveGetConstructSimple( name )
     local keys = self:PrimitiveGetKeys()
     local clips = ImprovedClipping and ImprovedClipping.GetClips( self )
-    return Primitive.construct.get( name, keys, CLIENT, keys.PrimMESHPHYS, clips )
+    local valid, result = Primitive.construct.get( name, keys, CLIENT, keys.PrimMESHPHYS, clips )
+
+    -- Clips should not be sealed for multi convex (the hole could be concave and that's out of scope).
+    self.ImprovedClippingAllowSeal = not ( istable( result ) and result.multiConvex )
+
+    return valid, result
 end
 
 

--- a/lua/primitive/entities/base.lua
+++ b/lua/primitive/entities/base.lua
@@ -7,6 +7,16 @@ local SERVER = SERVER
 
 local class = { Type = "anim", Base = "base_anim", Spawnable = false, AdminOnly = true, IsPrimitive = true }
 
+-- Lets ImprovedClipping skip its own physics rebuild/render override; we apply clips ourselves.
+class.ImprovedClippingExternalMesh = true
+
+-- Registered unconditionally since ImprovedClipping's load order isn't guaranteed relative to ours.
+hook.Add( "ImprovedClipping_ClipsChanged", "primitive_clipping", function( ent )
+    if IsValid( ent ) and ent.IsPrimitive then
+        ent:PrimitiveReconstruct()
+    end
+end )
+
 
 function class:PrimitivePostEntityPaste( ply, ent, createdEntities )
     self:SetPrimDEBUG( 0 )
@@ -60,7 +70,8 @@ end
 
 function class:PrimitiveGetConstructSimple( name )
     local keys = self:PrimitiveGetKeys()
-    return Primitive.construct.get( name, keys, CLIENT, keys.PrimMESHPHYS )
+    local clips = ImprovedClipping and ImprovedClipping.GetClips( self )
+    return Primitive.construct.get( name, keys, CLIENT, keys.PrimMESHPHYS, clips )
 end
 
 
@@ -195,6 +206,10 @@ local function rescale( self, scalar )
 end
 
 function class:PrimitiveRebuildPhysics( result )
+    -- Rebuilding a parented primitive would cause issues with the hitbox. Unparent and reparent
+    local parent = SERVER and self:GetParent() or nil
+    if IsValid( parent ) then self:SetParent( nil ) end
+
     local props
     if SERVER then
         props = self:PrimitiveGetProperties()
@@ -254,6 +269,8 @@ function class:PrimitiveRebuildPhysics( result )
 
         self:PrimitiveSetProperties( props )
     end
+
+    if IsValid( parent ) then self:SetParent( parent ) end
 end
 
 


### PR DESCRIPTION
Adds support for ImprovedClipping by cutting the physics meshes of primitives via the existing bisect function.

This was done by adding additional face data on the server, to create a triangle physics mesh.

Sealed clips are only supported for the single convex shapes (e.g. cube) and are not supported for multi convex shapes (e.g. tubes). You can still clip them and the physics will be clipped, but the cut will not be visually sealed.

More explicitly:
- `construct.get`/`generate` accept an optional clips list, threaded down to `getResult`, which bisects the built mesh against them and rebuilds convexes for physics.
- Added `simpleton:ApplyClips`, which cuts a simpleton against a list of clip planes, capping per each clip's Seal flag.
- Added `simpleton:PushConvex`/`PushBoxConvex`, which is used to store convex data on shapes, for use with bisect.
- Added an optional argument to `PushPrefab` to build a matching convex simpleton, for the compositional shapes such as `rail_slider`, `airfoil`, etc.
- Note that `airfoil` cannot be clipped because it is just an arbitrary point cloud, not a set of convexes.